### PR TITLE
Fix for inner class inside interfaces

### DIFF
--- a/src/main/java/com/ibm/minerva/analyzer/ClassProcessor.java
+++ b/src/main/java/com/ibm/minerva/analyzer/ClassProcessor.java
@@ -184,12 +184,22 @@ public final class ClassProcessor {
             // Filter out local and anonymous classes.
             final int index = name.lastIndexOf('$');
             if (index >= 0) {
+            	String parentName = name.substring(0,index);
                 name = name.substring(index+1);
                 if (name.length() > 0) {
                     final char c = name.charAt(0);
                     if (c >= '0' && c <= '9') {
                         return false;
                     }
+                }
+                // Filter out inner classes inside interfaces
+                if (parentName.length() > 0) {
+                	for(String interf:this.getInterfaces()) {
+                		String interfaceName = interf.substring(interf.lastIndexOf(".")+1);
+                		if (parentName.equals(interfaceName)) {
+                			return false;	
+                		}
+                	}
                 }
             }
         }

--- a/src/main/java/com/ibm/minerva/analyzer/ClassProcessor.java
+++ b/src/main/java/com/ibm/minerva/analyzer/ClassProcessor.java
@@ -184,22 +184,12 @@ public final class ClassProcessor {
             // Filter out local and anonymous classes.
             final int index = name.lastIndexOf('$');
             if (index >= 0) {
-            	String parentName = name.substring(0,index);
                 name = name.substring(index+1);
                 if (name.length() > 0) {
                     final char c = name.charAt(0);
                     if (c >= '0' && c <= '9') {
                         return false;
                     }
-                }
-                // Filter out inner classes inside interfaces
-                if (parentName.length() > 0) {
-                	for(String interf:this.getInterfaces()) {
-                		String interfaceName = interf.substring(interf.lastIndexOf(".")+1);
-                		if (parentName.equals(interfaceName)) {
-                			return false;	
-                		}
-                	}
                 }
             }
         }

--- a/src/main/java/com/ibm/minerva/analyzer/TableBuilder.java
+++ b/src/main/java/com/ibm/minerva/analyzer/TableBuilder.java
@@ -65,6 +65,10 @@ public final class TableBuilder implements ApplicationProcessor {
     private final Set<String> skippedClasses = new LinkedHashSet<>();
     private final Map<String,Set<String>> duplicateClassMap = new LinkedHashMap<>();
 
+    // TODO: temp solution to remove inner classes without parent (when parent is an interface)
+    private final Set<String> allInterfaces = new LinkedHashSet<>();
+    private final Set<String> allInnerClasses = new LinkedHashSet<>();
+
     private CallGraphBuilder callGraphBuilder;
     private Set<String> packages;
     private boolean isPackageIncludeList;
@@ -86,6 +90,19 @@ public final class TableBuilder implements ApplicationProcessor {
 
     public void process(ClassProcessor cp, byte[] bytes) {
         final String fqcn = cp.toFQCN();
+        final String simpleName = cp.getCtClass().getSimpleName();
+        
+        if (simpleName != null && simpleName.length() > 0) {
+        	final int index = simpleName.lastIndexOf('$');
+            if (index >= 0) {
+            	allInnerClasses.add(fqcn);
+            }
+        }
+        
+        if (cp.getCtClass().isInterface()) {
+        	allInterfaces.add(fqcn);
+        }
+
         if (isIncludedPackage(cp) && cp.isStandardNamedClass(allowAnyLegalClasses)) {
             if (!fqcns.contains(fqcn)) {
                 logger.info(() -> formatMessage("AnalyzingClass", cp.getCtClass().getName()));
@@ -147,6 +164,7 @@ public final class TableBuilder implements ApplicationProcessor {
     }
 
     public void write() throws IOException {
+        removeInnerClassesInsideInterfaces();
         resolveDuplicateClassMappings();
         if (tableDir.mkdirs()) {
             logger.info(() -> formatMessage("DirectoryCreated", tableDir));
@@ -620,5 +638,30 @@ public final class TableBuilder implements ApplicationProcessor {
                 });
             }
         }
+    }
+
+    // Removing inner classes which the parent is an interface. This is important because we do not
+    // give recommendations for interfaces, which result in inner classes without a parent in the table files.
+    private void removeInnerClassesInsideInterfaces() {
+    	for (String innerClass:allInnerClasses) {
+    		int index = innerClass.indexOf("$");
+    		if (index >= 0) {
+    			String parentFQCN = innerClass.substring(0,index-1);
+    			
+    			if (allInterfaces.contains(parentFQCN)) {
+    				int parentNameIndex = parentFQCN.lastIndexOf(".");
+        			String compoundName = innerClass.substring(parentNameIndex+1);
+        			compoundName = compoundName.replace(".$", "::");
+        			
+    				symTable.remove(compoundName);
+    				// refTable.remove(compoundName); // refTable is more complex because has different entries for the same class
+    				// but does not cause a fail in the process when the parent class of a inner class is not in the table 
+    				fqcns.remove(innerClass);
+    				
+    				logger.warning("The Class "+innerClass+" is defined inside an interface and will not be analyzed.");
+    			}
+    		}
+    	}
+    	
     }
 }

--- a/src/main/java/com/ibm/minerva/analyzer/TableBuilder.java
+++ b/src/main/java/com/ibm/minerva/analyzer/TableBuilder.java
@@ -644,7 +644,7 @@ public final class TableBuilder implements ApplicationProcessor {
     // give recommendations for interfaces, which result in inner classes without a parent in the table files.
     private void removeInnerClassesInsideInterfaces() {
     	for (String innerClass:allInnerClasses) {
-    		int index = innerClass.indexOf("$");
+    		int index = innerClass.lastIndexOf("$");
     		if (index >= 0) {
     			String parentFQCN = innerClass.substring(0,index-1);
     			
@@ -654,7 +654,7 @@ public final class TableBuilder implements ApplicationProcessor {
         			compoundName = compoundName.replace(".$", "::");
         			
     				symTable.remove(compoundName);
-    				// refTable.remove(compoundName); // refTable is more complex because has different entries for the same class
+    				// refTable.remove // refTable is more complex because has different entries for the same class
     				// but does not cause a fail in the process when the parent class of a inner class is not in the table 
     				fqcns.remove(innerClass);
     				

--- a/src/main/java/com/ibm/minerva/analyzer/TableBuilder.java
+++ b/src/main/java/com/ibm/minerva/analyzer/TableBuilder.java
@@ -662,6 +662,8 @@ public final class TableBuilder implements ApplicationProcessor {
     			}
     		}
     	}
-    	
+    	// deallocate global variable memories that will not be used anymore
+    	allInnerClasses.clear();
+    	allInterfaces.clear();
     }
 }


### PR DESCRIPTION
** Important: this is a temp fix, and it does not include fixes for refTable.json, just symTable.json.

This code was tested with defaultapp modified with some classes inside Interfaces. In some cases the inner class is implementing the interface, in other cases not, as this one:

```
package com.ibm.defaultapplication;

public interface TestInterface2 
{
    void printM2M();
    void printM2M(String value);

    public static class TestPrint
    {
        public void printM2M() {
            System.out.println("***** Mono2Micro print test *****");
        }
        
        public void printM2M(String value) {
            System.out.println("***** Mono2Micro print test "+value+" *****");
        }
    }
}
```

When running with the finest log enabled, it shows the inner class has been skipped:

```
At least one of these files is in directory /Users/fabiofranco/Downloads/defaultapp/analysis/test-fix: "symTable.json", "instrumenter-config.json", or "refTable.json". Do you want to overwrite them? Enter 1 for Yes or 2 for No: 1
All packages in the application will be analyzed
Starting Minerva Binary Analyzer
Analyzing archive /Users/fabiofranco/Downloads/defaultapp/DefaultApplication.ear.
Analyzing class com.ibm.defaultapplication.SnoopServlet.
Analyzing class com.ibm.defaultapplication.TestInterface$TestPrint.
Analyzing class com.ibm.defaultapplication.IncrementAction.
Analyzing class com.ibm.defaultapplication.Increment.
Analyzing class com.ibm.defaultapplication.HitCount.
Analyzing class com.ibm.defaultapplication.TestInterface2$TestPrint.
Analyzing class com.ibm.defaultapplication.IncrementSSB.
Analyzing class com.ibm.defaultapplication.TestInterface3$TestPrint.
Analyzing class com.ibm.defaultapplication.TestInterface4$TestPrint.
[WARNING] The Class com.ibm.defaultapplication.TestInterface.$TestPrint is defined inside an interface and will not be analyzed.
[WARNING] The Class com.ibm.defaultapplication.TestInterface2.$TestPrint is defined inside an interface and will not be analyzed.
[WARNING] The Class com.ibm.defaultapplication.TestInterface3.$TestPrint is defined inside an interface and will not be analyzed.
[WARNING] The Class com.ibm.defaultapplication.TestInterface4.$TestPrint is defined inside an interface and will not be analyzed.
Writing file /Users/fabiofranco/Downloads/defaultapp/analysis/test-fix/symTable.json.
Writing file /Users/fabiofranco/Downloads/defaultapp/analysis/test-fix/refTable.json.
Writing file /Users/fabiofranco/Downloads/defaultapp/analysis/test-fix/instrumenter-config.json.
******************************
COMPLETED
******************************

Next steps: Collect more data by running use cases on your instrumented application with the "mono2micro usecase" command. Read this section of the Mono2Micro documentation for more details: https://www.ibm.com/docs/SS7H9Y/doc/m2m_dct_bininst.html
```